### PR TITLE
text overflow ellipsis

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -121,6 +121,7 @@ body{
   vertical-align: middle;
   overflow: hidden;
   white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .song_table tbody > tr > td .unknown_cover {
   vertical-align: top;


### PR DESCRIPTION
ends song titles with ... when it doesn't fit and doesn't let the + overlap the text (I was surprised by that too)
