### PR TITLE
Bugfix for #24

### DIFF
--- a/static/js/player/detailview.js
+++ b/static/js/player/detailview.js
@@ -46,6 +46,10 @@ function shoInfoView(items){
 
     // redraw the song
     MusicApp.router.songview.redrawSong(data._id);
+
+    if(player.playing_id === data._id) {
+      MusicApp.infoRegion.currentView.render();
+    }
   };
   bootbox.dialog({
     title: track.attributes.title,


### PR DESCRIPTION
When the songview of the current playing song changes. The info in the bottom bar is now re-rendered

Should fix #24 
