### PR TITLE
fix missing dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fluent-ffmpeg": "~2.0.0-rc1"
   },
   "devDependencies": {
+    "electron-packager": "^8.2.0",
     "grunt": "^0.4.5",
     "grunt-bower-install-simple": "^1.2.0",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
add electron-packager to devDependencies. required by
electronres/buildpackages.sh